### PR TITLE
MemClkOffset: Memory frequency mix-up

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -72,8 +72,8 @@ MainWindow::MainWindow(QWidget *parent) :
         // Divide by 2 to get the clock speed
         ui->memClkSlider->setRange(nv->GPUList[currentGPUIndex].minMemClkOffset/2, nv->GPUList[currentGPUIndex].maxMemClkOffset/2);
         ui->memClkSpinBox->setRange(nv->GPUList[currentGPUIndex].minMemClkOffset/2, nv->GPUList[currentGPUIndex].maxMemClkOffset/2);
-        ui->memClkSlider->setValue(nv->GPUList[currentGPUIndex].memClkOffset);
-        ui->memClkSpinBox->setValue(nv->GPUList[currentGPUIndex].memClkOffset);
+        ui->memClkSlider->setValue(nv->GPUList[currentGPUIndex].memClkOffset/2);
+        ui->memClkSpinBox->setValue(nv->GPUList[currentGPUIndex].memClkOffset/2);
     } else {
         ui->memClkSlider->setEnabled(false);
         ui->memClkSpinBox->setEnabled(false);
@@ -724,7 +724,7 @@ void MainWindow::applyGPUSettings()
         ret = nv->assignGPUMemClockOffset(currentGPUIndex, offsetValue*2);
         if (ret) {
             nv->GPUList[currentGPUIndex].memClkOffset = offsetValue*2;
-            settings.setValue("memoryClockOffset", offsetValue*2);
+            settings.setValue("memoryClockOffset", offsetValue);
         } else {
             errorText.append("- Memory Clock Offset");
             hadErrors = true;
@@ -1102,7 +1102,7 @@ void MainWindow::on_GPUComboBox_currentIndexChanged(int index)
     }
 
     if (nv->GPUList[index].memOverClockAvailable) {
-        ui->memClkSlider->setRange(nv->GPUList[index].minMemClkOffset, nv->GPUList[index].maxMemClkOffset);
+        ui->memClkSlider->setRange(nv->GPUList[index].minMemClkOffset/2, nv->GPUList[index].maxMemClkOffset/2);
     } else {
         ui->memClkSlider->setEnabled(false);
         ui->memClkSpinBox->setEnabled(false);

--- a/nvidia.cpp
+++ b/nvidia.cpp
@@ -307,6 +307,7 @@ void nvidia::queryGPUMemClkOffset(int GPUIndex)
                                            GPUList[GPUIndex].maxPerfMode,
                                            NV_CTRL_GPU_MEM_TRANSFER_RATE_OFFSET,
                                            &GPUList[GPUIndex].memClkOffset);
+    GPUList[GPUIndex].memClkOffset /= 2;
 }
 void nvidia::queryGPUVoltageOffset(int GPUIndex)
 {

--- a/nvidia.cpp
+++ b/nvidia.cpp
@@ -307,7 +307,6 @@ void nvidia::queryGPUMemClkOffset(int GPUIndex)
                                            GPUList[GPUIndex].maxPerfMode,
                                            NV_CTRL_GPU_MEM_TRANSFER_RATE_OFFSET,
                                            &GPUList[GPUIndex].memClkOffset);
-    GPUList[GPUIndex].memClkOffset /= 2;
 }
 void nvidia::queryGPUVoltageOffset(int GPUIndex)
 {


### PR DESCRIPTION
MemClkOffset is internally handled as the actual memory frequency of the GPU but the query for its attribute returns the Double Data Rate frequency.
If the user already manipulated the memory clock offsets outside of tuxclocker (e.g. via NVIDIA X Server Settings), subsequent changes to the memory frequency can lead to too high clock rates, without the user realizing.

I don't know if this problem is a general one, but I encountered it with my GTX 970.
And unfortunately I don't have any other GPU to test it on.