### PR TITLE
Minimize to tray if available

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -1149,7 +1149,7 @@ QMenu* MainWindow::createMenu()
 {
     auto menu = new QMenu(this);
 
-    QAction* show = new QAction("&Open settings", this);
+    QAction* show = new QAction("&Maximize TuxClocker", this);
     connect(show, &QAction::triggered, this, [=]{MainWindow::show();});
     menu->addAction(show);
 

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -130,7 +130,7 @@ MainWindow::MainWindow(QWidget *parent) :
 
     /*Create tray icon */
     {
-        auto appIcon = QIcon(":/icons/gpuonfire.svg");
+        auto appIcon = QIcon(QPixmap(":/icons/gpuonfire.svg"));
 
         if (!QSystemTrayIcon::isSystemTrayAvailable())
         {

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -1163,6 +1163,34 @@ QMenu* MainWindow::createMenu()
 
 void MainWindow::closeEvent(QCloseEvent* e)
 {
-    MainWindow::hide();
-    if(ignore_closeEvent) e->ignore();
+    if(!ignore_closeEvent)
+    {
+        //Just quit if system tray is unavailable
+        QApplication::quit();
+    }
+
+    QMessageBox mb(QMessageBox::Warning,
+                   QString("TuxClocker"),
+                   QString("Do you want to close or minimize to tray?"),
+                   QMessageBox::NoButton, this);
+
+    QPushButton *closeBtn = mb.addButton(QString("Close"), QMessageBox::YesRole);
+    QPushButton *minimizeBtn = mb.addButton(QString("Minimize"), QMessageBox::NoRole);
+    QPushButton *cancelBtn = mb.addButton(QString("Cancel"), QMessageBox::RejectRole);
+
+    mb.setDefaultButton(closeBtn);
+    mb.setEscapeButton(cancelBtn);
+    mb.exec();
+
+    if (mb.clickedButton() == minimizeBtn)
+    {
+        MainWindow::hide();
+        e->ignore();
+        return;
+    }
+    else if (mb.clickedButton() == cancelBtn)
+    {
+        e->ignore();
+        return;
+    }
 }

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -134,9 +134,7 @@ MainWindow::MainWindow(QWidget *parent) :
 
         if (!QSystemTrayIcon::isSystemTrayAvailable())
         {
-#ifdef dbg
-            std::cout << "Qt: System tray unavailable.\n";
-#endif
+            qDebug() << "Qt: System tray unavailable";
             ignore_closeEvent = false;
             MainWindow::show();
         }

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -251,6 +251,10 @@ private:
     plotCmds fanspeedplot;
     QVector <plotCmds> plotCmdsList;
 
+    QSystemTrayIcon* trayIcon;
+    QMenu* createMenu();
+    void closeEvent(QCloseEvent *);
+    bool ignore_closeEvent = true;
 };
 
 #endif // MAINWINDOW_H


### PR DESCRIPTION
Adds a system tray icon with gpuonfire.svg image.
Closing the window won't quit the program, unless you click on "Quit" from the tray menu. 
If Qt does not detect a tray, closing the window will quit the app as it did before.