### PR TITLE
Add Qt X11 Extras to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,25 +27,25 @@ Matrix room: #tuxclocker:matrix.org [Direct Riot link](https://riot.im/app/#/roo
 For AMD under Ubuntu:
 
     sudo apt install --yes --quiet --quiet \
-    	libqt5x11extras5-dev \
-	qtbase5-dev \
-	libqt5x11extras5 \
-	libdrm-amdgpu1 \
-	libdrm-common \
-	libdrm-dev
+        libqt5x11extras5-dev \
+        qtbase5-dev \
+        libqt5x11extras5 \
+        libdrm-amdgpu1 \
+        libdrm-common \
+        libdrm-dev
 
 For Nvidia under Ubuntu:
 
     sudo apt install --yes --quiet --quiet \
-    	libqt5x11extras5-dev \
-	qtbase5-dev \
-	libqt5x11extras5 \
-	libdrm-amdgpu1 \
-	libdrm-common \
-	libdrm-dev \
-	nvidia-utils-440-server \
-	nvidia-settings \
-	libxnvctrl-dev
+        libqt5x11extras5-dev \
+        qtbase5-dev \
+        libqt5x11extras5 \
+        libdrm-amdgpu1 \
+        libdrm-common \
+        libdrm-dev \
+        nvidia-utils-440-server \
+        nvidia-settings \
+        libxnvctrl-dev
 
 # Requirements (nvidia)
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
-TuxClocker - A GUI overclocking utility for GNU/Linux
-========================================
+# TuxClocker - A GUI overclocking utility for GNU/Linux
+
 TuxClocker is a Qt5 overclocking tool. Currently supported cards are nvidia 600-series cards and newer, and AMD GPUs using the amdgpu driver until (not including) Radeon VII.
 
 # Support
+
 Matrix room: #tuxclocker:matrix.org [Direct Riot link](https://riot.im/app/#/room/#tuxclocker:matrix.org)
 
 # Screenshots
@@ -10,6 +11,7 @@ Matrix room: #tuxclocker:matrix.org [Direct Riot link](https://riot.im/app/#/roo
 ![Imgur](https://i.imgur.com/fn8MoNj.png) ![Imgur](https://i.imgur.com/fuKIVW7.png) ![Imgur](https://i.imgur.com/cZCNzmN.png) ![Imgur](https://i.imgur.com/qkp2p7V.png) ![Imgur](https://i.imgur.com/TpmU8PD.png)
 
 # Current features
+
 - GPU monitoring (list and graph)
 - Overclocking
 - Overvolting
@@ -62,14 +64,14 @@ qmake rojekti.pro
 make
 make install (installs into /opt/tuxclocker/bin)
 ```
+
 ### Arch Linux
+
 #### AUR package
 [https://aur.archlinux.org/packages/tuxclocker/](https://aur.archlinux.org/packages/tuxclocker/)
 
 # Requirements (AMD)
 
-- NOTE: headers are usually included in a package named \*-dev, if they are separate
-- libdrm and headers
 - amdgpu.ppfeaturemask boot paramter set to the value you want. To view the current value, run 
 
 ```

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ make install (installs into /opt/tuxclocker/bin)
 
 - NOTE: headers are usually included in a package named \*-dev, if they are separate
 - libdrm and headers
+- libqt5x11extras5
 - amdgpu.ppfeaturemask boot paramter set to the value you want. To view the current value, run 
 
 ```

--- a/README.md
+++ b/README.md
@@ -20,12 +20,33 @@ Matrix room: #tuxclocker:matrix.org [Direct Riot link](https://riot.im/app/#/roo
 - Provisional multi-GPU support
 - Profiles
 
+# Prerequisites
+
+For AMD under Ubuntu:
+
+    sudo apt install --yes --quiet --quiet \
+    	libqt5x11extras5-dev \
+	qtbase5-dev \
+	libqt5x11extras5 \
+	libdrm-amdgpu1 \
+	libdrm-common \
+	libdrm-dev
+
+For Nvidia under Ubuntu:
+
+    sudo apt install --yes --quiet --quiet \
+    	libqt5x11extras5-dev \
+	qtbase5-dev \
+	libqt5x11extras5 \
+	libdrm-amdgpu1 \
+	libdrm-common \
+	libdrm-dev \
+	nvidia-utils-440-server \
+	nvidia-settings \
+	libxnvctrl-dev
+
 # Requirements (nvidia)
-- NOTE: headers are usually included in a package named \*-dev, if they are separate
-- nvidia-smi
-- nvidia-settings
-- libxnvctrl and headers (if not included in nvidia-settings)
-- qt5base, x11extras and their headers
+
 - [Coolbits](https://wiki.archlinux.org/index.php/NVIDIA/Tips_and_tricks#Enabling_overclocking) set to the value you want (31 for all functionality)
 
 # Installation (nvidia)
@@ -49,7 +70,6 @@ make install (installs into /opt/tuxclocker/bin)
 
 - NOTE: headers are usually included in a package named \*-dev, if they are separate
 - libdrm and headers
-- libqt5x11extras5
 - amdgpu.ppfeaturemask boot paramter set to the value you want. To view the current value, run 
 
 ```

--- a/README.md
+++ b/README.md
@@ -24,6 +24,11 @@ Matrix room: #tuxclocker:matrix.org [Direct Riot link](https://riot.im/app/#/roo
 
 # Prerequisites
 
+For AMD under any distribution:
+
+-   NOTE: headers are usually included in a package named \*-dev, if they are separate
+-   libdrm and headers
+
 For AMD under Ubuntu:
 
     sudo apt install --yes --quiet --quiet \
@@ -33,6 +38,14 @@ For AMD under Ubuntu:
         libdrm-amdgpu1 \
         libdrm-common \
         libdrm-dev
+
+For Nvidia under any distribution:
+
+-   NOTE: headers are usually included in a package named \*-dev, if they are separate
+-   nvidia-smi
+-   nvidia-settings
+-   libxnvctrl and headers (if not included in nvidia-settings)
+-   qt5base, x11extras and their headers
 
 For Nvidia under Ubuntu:
 


### PR DESCRIPTION
I needed to install the package `libqt5x11extras5-dev` to be able to compile. So I would suggest adding it to the readme. Full log:

```
$ qmake rojekti.pro
Project ERROR: Unknown module(s) in QT: x11extras
$ sudo apt install --yes libqt5x11extras5-dev
Reading package lists... Done
Building dependency tree       
Reading state information... Done
The following NEW packages will be installed:
  libqt5x11extras5-dev
0 upgraded, 1 newly installed, 0 to remove and 0 not upgraded.
Need to get 7.236 B of archives.
After this operation, 52,2 kB of additional disk space will be used.
Get:1 http://de.archive.ubuntu.com/ubuntu bionic/universe amd64 libqt5x11extras5-dev amd64 5.9.5-0ubuntu1 [7.236 B]
Fetched 7.236 B in 0s (99,8 kB/s)         
Selecting previously unselected package libqt5x11extras5-dev:amd64.
(Reading database ... 355971 files and directories currently installed.)
Preparing to unpack .../libqt5x11extras5-dev_5.9.5-0ubuntu1_amd64.deb ...
Unpacking libqt5x11extras5-dev:amd64 (5.9.5-0ubuntu1) ...
Setting up libqt5x11extras5-dev:amd64 (5.9.5-0ubuntu1) ...
$ qmake rojekti.pro
```