### PR TITLE
Double-clicking tray icon now shows main window

### DIFF
--- a/src/tuxclocker-qt/MainWindow.cpp
+++ b/src/tuxclocker-qt/MainWindow.cpp
@@ -111,6 +111,8 @@ void MainWindow::setTrayIconEnabled(bool enable) {
 		m_trayIcon->setToolTip("TuxClocker");
 		m_trayIcon->setContextMenu(createTrayMenu());
 		m_trayIcon->show();
+		connect(m_trayIcon, &QSystemTrayIcon::activated, this,
+		    &MainWindow::show);
 		return;
 	}
 	// Remove tray icon


### PR DESCRIPTION
Pretty straightforward, simply connects the `activated` signal for the tray icon to the `show` slot for `MainWindow`. This allows the tray icon to be double-clicked to show the TuxClocker window.