### PR TITLE
Build fix 

### DIFF
--- a/src/include/Plugin.hpp
+++ b/src/include/Plugin.hpp
@@ -41,7 +41,7 @@ public:
 	virtual ~DevicePlugin() {}
 
 	// Helper for loading all DevicePlugin's
-	static std::optional<std::vector<boost::shared_ptr<DevicePlugin>>> loadPlugins();
+	static  std::optional<std::vector<boost::shared_ptr<DevicePlugin>>> loadPlugins();
 };
 
 }; // namespace Plugin

--- a/src/lib/Plugin.cpp
+++ b/src/lib/Plugin.cpp
@@ -9,30 +9,33 @@ namespace fs = std::filesystem;
 
 std::string Plugin::pluginPath() { return TC_PLUGIN_PATH; }
 
-std::optional<std::vector<boost::shared_ptr<DevicePlugin>>> DevicePlugin::loadPlugins() {
-	std::vector<boost::shared_ptr<DevicePlugin>> retval;
+std::optional<std::vector<boost::shared_ptr<DevicePlugin>>>
+DevicePlugin::loadPlugins() {
+    std::vector<boost::shared_ptr<DevicePlugin>> retval;
 
-	std::string pluginPath;
-	const char *pluginPathEnv = std::getenv("TUXCLOCKER_PLUGIN_PATH");
+    std::string pluginPath;
+    const char *pluginPathEnv = std::getenv("TUXCLOCKER_PLUGIN_PATH");
 
-	// Use plugin path from environment if it exists
-	if (pluginPathEnv)
-		pluginPath = pluginPathEnv;
-	else
-		pluginPath = Plugin::pluginPath();
+    if (pluginPathEnv)
+        pluginPath = pluginPathEnv;
+    else
+        pluginPath = Plugin::pluginPath();
 
-	for (const fs::directory_entry &entry : fs::directory_iterator(pluginPath)) {
-		// Bleh, have to catch this unless I do more manual checks
-		try {
-			auto plugin = boost::dll::import_symbol<DevicePlugin>(
-			    entry.path().string(), TUXCLOCKER_PLUGIN_SYMBOL_NAME);
-			retval.push_back(plugin);
-			std::cout << "found plugin at " << entry.path().string() << "\n";
-		} catch (boost::system::system_error &e) {
-		}
-	}
+    for (const fs::directory_entry &entry : fs::directory_iterator(pluginPath)) {
+        try {
+            auto plugin = boost::dll::import_symbol<DevicePlugin>(
+                entry.path().string(),
+                TUXCLOCKER_PLUGIN_SYMBOL_NAME
+            );
 
-	if (retval.empty())
-		return std::nullopt;
-	return retval;
+            retval.push_back(plugin);
+            std::cout << "found plugin at " << entry.path().string() << "\n";
+        } catch (const boost::system::system_error &) {
+        }
+    }
+
+    if (retval.empty())
+        return std::nullopt;
+
+    return retval;
 }


### PR DESCRIPTION
for this 

`
[2/7] Compiling C++ object src/libtuxclocker.so.p/lib_Plugin.cpp.o FAILED: src/libtuxclocker.so.p/lib_Plugin.cpp.o ccache c++ -Isrc/libtuxclocker.so.p -Isrc -I../src -I../src/include -I../src/include/deps -I/usr/include -fdiagnostics-color=always -D_GLIBCXX_ASSERTIONS=1 -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -std=c++17 '-DGETTEXT_PACKAGE="tuxclocker"' -O2 -g -pipe -Wformat -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -fstack-protector --param=ssp-buffer-size=4 -fasynchronous-unwind-tables -fPIC -DBOOST_SYSTEM_DYN_LINK=1 -DBOOST_FILESYSTEM_DYN_LINK=1 -DBOOST_ALL_NO_LIB '-DTC_PLUGIN_PATH="/usr/lib64/tuxclocker/plugins"' -MD -MQ src/libtuxclocker.so.p/lib_Plugin.cpp.o -MF src/libtuxclocker.so.p/lib_Plugin.cpp.o.d -o src/libtuxclocker.so.p/lib_Plugin.cpp.o -c ../src/lib/Plugin.cpp ../src/lib/Plugin.cpp: In static member function ‘static std::optional<std::vector<std::shared_ptr<TuxClocker::Plugin::DevicePlugin> > > TuxClocker::Plugin::DevicePlugin::loadPlugins()’: ../src/lib/Plugin.cpp:29:41: error: no matching function for call to ‘std::vector<std::shared_ptr<TuxClocker::Plugin::DevicePlugin> >::push_back(boost::shared_ptr<TuxClocker::Plugin::DevicePlugin>&)’ 29 | retval.push_back(plugin); | ~~~~~~~~~~~~~~~~^~~~~~~~ In file included from /usr/include/c++/14/vector:66, from /usr/include/c++/14/functional:64, from /usr/include/boost/system/detail/error_category.hpp:17, from /usr/include/boost/system/error_category.hpp:10, from /usr/include/boost/filesystem/detail/path_traits.hpp:25, from /usr/include/boost/filesystem/path.hpp:21, from /usr/include/boost/dll/config.hpp:59, from /usr/include/boost/dll/import.hpp:11, from ../src/include/Plugin.hpp:4, from ../src/lib/Plugin.cpp:1: /usr/include/c++/14/bits/stl_vector.h:1283:7: note: candidate: ‘void std::vector<_Tp, _Alloc>::push_back(const value_type&) [with _Tp = std::shared_ptr<TuxClocker::Plugin::DevicePlugin>; _Alloc = std::allocator<std::shared_ptr<TuxClocker::Plugin::DevicePlugin> >; value_type = std::shared_ptr<TuxClocker::Plugin::DevicePlugin>]’ 1283 | push_back(const value_type& __x) | ^~~~~~~~~ /usr/include/c++/14/bits/stl_vector.h:1283:35: note: no known conversion for argument 1 from ‘boost::shared_ptr<TuxClocker::Plugin::DevicePlugin>’ to ‘const std::vector<std::shared_ptr<TuxClocker::Plugin::DevicePlugin> >::value_type&’ {aka ‘const std::shared_ptr<TuxClocker::Plugin::DevicePlugin>&’} 1283 | push_back(const value_type& __x) | ~~~~~~~~~~~~~~~~~~^~~ /usr/include/c++/14/bits/stl_vector.h:1300:7: note: candidate: ‘void std::vector<_Tp, _Alloc>::push_back(value_type&&) [with _Tp = std::shared_ptr<TuxClocker::Plugin::DevicePlugin>; _Alloc = std::allocator<std::shared_ptr<TuxClocker::Plugin::DevicePlugin> >; value_type = std::shared_ptr<TuxClocker::Plugin::DevicePlugin>]’ 1300 | push_back(value_type&& __x) | ^~~~~~~~~ /usr/include/c++/14/bits/stl_vector.h:1300:30: note: no known conversion for argument 1 from ‘boost::shared_ptr<TuxClocker::Plugin::DevicePlugin>’ to ‘std::vector<std::shared_ptr<TuxClocker::Plugin::DevicePlugin> >::value_type&&’ {aka ‘std::shared_ptr<TuxClocker::Plugin::DevicePlugin>&&’} 1300 | push_back(value_type&& __x) | ~~~~~~~~~~~~~^~~ ninja: build stopped: subcommand failed.`