### PR TITLE
Fix GCC and Clang compilation, add Boost std::shared_ptr backwards-compatible fix

### DIFF
--- a/src/include/Plugin.hpp
+++ b/src/include/Plugin.hpp
@@ -2,8 +2,18 @@
 
 #include <boost/config.hpp>
 #include <boost/dll/import.hpp>
+#include <boost/version.hpp>
 #include <optional>
 #include <string>
+
+// boost::dll::import_symbol returns std::shared_ptr starting from Boost 1.88
+#if BOOST_VERSION >= 108800
+#include <memory>
+#define TC_PLUGIN_PTR std::shared_ptr
+#else
+#include <boost/shared_ptr.hpp>
+#define TC_PLUGIN_PTR boost::shared_ptr
+#endif
 
 #include "Device.hpp"
 #include "Tree.hpp"
@@ -41,7 +51,7 @@ public:
 	virtual ~DevicePlugin() {}
 
 	// Helper for loading all DevicePlugin's
-	static std::optional<std::vector<boost::shared_ptr<DevicePlugin>>> loadPlugins();
+	static std::optional<std::vector<TC_PLUGIN_PTR<DevicePlugin>>> loadPlugins();
 };
 
 }; // namespace Plugin

--- a/src/lib/Plugin.cpp
+++ b/src/lib/Plugin.cpp
@@ -1,6 +1,7 @@
 #include <Plugin.hpp>
 
 #include <filesystem>
+#include <iostream>
 #include <sstream>
 
 using namespace TuxClocker::Plugin;
@@ -9,8 +10,8 @@ namespace fs = std::filesystem;
 
 std::string Plugin::pluginPath() { return TC_PLUGIN_PATH; }
 
-std::optional<std::vector<boost::shared_ptr<DevicePlugin>>> DevicePlugin::loadPlugins() {
-	std::vector<boost::shared_ptr<DevicePlugin>> retval;
+std::optional<std::vector<TC_PLUGIN_PTR<DevicePlugin>>> DevicePlugin::loadPlugins() {
+	std::vector<TC_PLUGIN_PTR<DevicePlugin>> retval;
 
 	std::string pluginPath;
 	const char *pluginPathEnv = std::getenv("TUXCLOCKER_PLUGIN_PATH");

--- a/src/plugins/CPU.cpp
+++ b/src/plugins/CPU.cpp
@@ -702,7 +702,7 @@ std::vector<TreeNode<DeviceNode>> getGovernors(CPUData data) {
 		std::vector<std::string> sysFsNames;
 		int enumId = 0;
 		for (auto &word : split_words(false, *contents)) {
-			auto e = Enumeration{fromSysFsName(word), enumId};
+			auto e = Enumeration{fromSysFsName(word), static_cast<uint>(enumId)};
 			enumId++;
 			enumVec.push_back(e);
 			sysFsNames.push_back(word);
@@ -789,7 +789,7 @@ std::vector<TreeNode<DeviceNode>> getEPPNodes(CPUData data) {
 
 		EnumerationVec enumVec;
 		for (int i = 0; i < sysFsNames.size(); i++) {
-			auto e = Enumeration{fromSysFsName(sysFsNames[i]), i};
+			auto e = Enumeration{fromSysFsName(sysFsNames[i]), static_cast<uint>(i)};
 			enumVec.push_back(e);
 		}
 

--- a/src/plugins/Nvidia.cpp
+++ b/src/plugins/Nvidia.cpp
@@ -153,7 +153,7 @@ std::vector<TreeNode<DeviceNode>> getMemClockWrite(NvidiaGPUData data) {
 		return {};
 	}
 	// Transfer rate -> clock speed
-	Range<int> range{values.u.range.min / 2, values.u.range.max / 2};
+	Range<int> range{static_cast<int>(values.u.range.min / 2), static_cast<int>(values.u.range.max / 2)};
 
 	// Seems the ..ALL_PERFORMANCE_LEVELS attribute doesn't work with the NVML function
 	auto setFuncNVML = [=](AssignmentArgument a) -> std::optional<AssignmentError> {
@@ -228,7 +228,7 @@ std::vector<TreeNode<DeviceNode>> getCoreClockWrite(NvidiaGPUData data) {
 		return {};
 	}
 
-	Range<int> range{values.u.range.min, values.u.range.max};
+	Range<int> range{static_cast<int>(values.u.range.min), static_cast<int>(values.u.range.max)};
 
 	auto setFunc = [=](AssignmentArgument a) -> std::optional<AssignmentError> {
 		if (!std::holds_alternative<int>(a))
@@ -777,7 +777,7 @@ std::vector<TreeNode<DeviceNode>> getVoltageOffset(NvidiaGPUData data) {
 		return {};
 
 	// uV -> mV
-	Range<int> range{values.u.range.min / 1000, values.u.range.max / 1000};
+	Range<int> range{static_cast<int>(values.u.range.min / 1000), static_cast<int>(values.u.range.max / 1000)};
 
 	auto getFunc = [data]() -> std::optional<AssignmentArgument> {
 		int value;


### PR DESCRIPTION
Continuation of https://github.com/Lurkki14/tuxclocker/pull/107

I'm calling out that this was vibe coded, so feel free to skip. The issue does exist though as we can see by the NixOS report here https://github.com/NixOS/nixpkgs/issues/504637. However after inspecting the changes, they do track almost 1:1 with the original PR, apart from the Boost version check/std::shared_ptr change, which Boost updated between then and now.

I tried re-opening the initial PR but it seems to not want to do that.

Some snippets the AI has used:
```
for ver in 1.82.0 1.83.0 1.84.0 1.85.0 1.86.0 1.87.0 1.88.0; do
  result=$(curl -s "https://raw.githubusercontent.com/boostorg/dll/boost-${ver}/include/boost/dll/config.hpp" 2>/dev/null | grep -c "BOOST_DLL_USE_BOOST_SHARED_PTR")
  echo "Boost ${ver}: ${result}"
done
```

## Testing
With GCC:
(I didn't bother to install)
```
meson build --prefix /tmp/tuxclocker -Drequire-nvidia=true -Drequire-amd=false -Drequire-python-hwdata=false -Dplugins=true -Ddaemon=true && ninja build
```
With Clang:
```
CC=clang CXX=clang++ meson build --prefix /tmp/tuxclocker -Drequire-nvidia=true -Drequire-amd=false -Drequire-python-hwdata=false -Dplugins=true -Ddaemon=true && ninja build
```